### PR TITLE
fetch img src on mousenter instead of init

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "phpunit/phpunit": "4.1.0"
     },
     "type": "magento2-module",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "license": [
         "proprietary"
     ],

--- a/view/frontend/web/js/mouseover-image.js
+++ b/view/frontend/web/js/mouseover-image.js
@@ -4,10 +4,11 @@ define(['jquery'], function($) {
         var $el = $(element);
         var $img = $el.find('img[data-alt-src]');
         var altSrc = $img.data('alt-src');
-        var src = $img.prop('src');
 
         if (altSrc !== '') {
             $el.on('mouseenter', function () {
+                var origSrc = $img.prop('src');
+
                 $img.prop({
                     src: altSrc
                 });
@@ -15,7 +16,7 @@ define(['jquery'], function($) {
 
             $el.on('mouseleave', function () {
                 $img.prop({
-                    src: src
+                    src: origSrc
                 });
             });
         }


### PR DESCRIPTION
fetch img src on mousenter instead of init to avoid overriding changes triggered by swatches. See [issue](https://github.com/Space48/MouseOverImage/issues/2).