### PR TITLE
Ensure event observers are applied

### DIFF
--- a/view/frontend/web/js/mouseover-image.js
+++ b/view/frontend/web/js/mouseover-image.js
@@ -1,13 +1,12 @@
 define(['jquery'], function($) {
 
     return function (config, element) {
-        var $el = $(element);
-        var $img = $el.find('img[data-alt-src]');
+        var $img = $(element);
         var altSrc = $img.data('alt-src');
         var origSrc = $img.prop('src');
 
         if (altSrc !== '') {
-            $el.on('mouseenter', function () {
+            $img.on('mouseenter', function () {
                 origSrc = $img.prop('src');
 
                 $img.prop({
@@ -15,7 +14,7 @@ define(['jquery'], function($) {
                 });
             });
 
-            $el.on('mouseleave', function () {
+            $img.on('mouseleave', function () {
                 $img.prop({
                     src: origSrc
                 });


### PR DESCRIPTION
This is a fix to ensure that event observers are applied to a found element. The template invokes on the img element so $img is currently an empty jQuery object. I believe this previous implementation may have been based on usage in a project where data-mage-init had been specified on a parent element.